### PR TITLE
Fix to serialization issue of StarkProof

### DIFF
--- a/air/src/air/mod.rs
+++ b/air/src/air/mod.rs
@@ -181,7 +181,7 @@ pub trait Air: Send + Sync {
     /// Base field for the computation described by this AIR. STARK protocol for this computation
     /// may be executed in the base field, or in an extension of the base fields as specified
     /// by [ProofOptions] struct.
-    type BaseField: StarkField + ExtensibleField<2> + ExtensibleField<3>;
+    type BaseField: StarkField + ExtensibleField<2> + ExtensibleField<3> + ExtensibleField<6>;
 
     /// A type defining shape of public inputs for the computation described by this protocol.
     /// This could be any type as long as it can be serialized into a sequence of bytes.

--- a/air/src/air/trace_info.rs
+++ b/air/src/air/trace_info.rs
@@ -33,7 +33,7 @@ impl TraceInfo {
     /// Smallest allowed execution trace length; currently set at 8.
     pub const MIN_TRACE_LENGTH: usize = 8;
     /// Maximum number of columns in an execution trace (across all segments); currently set at 255.
-    pub const MAX_TRACE_WIDTH: usize = 2047;
+    pub const MAX_TRACE_WIDTH: usize = 65535;
     /// Maximum number of bytes in trace metadata; currently set at 65535.
     pub const MAX_META_LENGTH: usize = 65535;
     /// Maximum number of random elements per auxiliary trace segment; currently set to 255.
@@ -272,7 +272,7 @@ impl TraceLayout {
 impl Serializable for TraceLayout {
     /// Serializes `self` and writes the resulting bytes into the `target`.
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write_u8(self.main_segment_width as u8);
+        target.write_u16(self.main_segment_width as u16);
         for &w in self.aux_segment_widths.iter() {
             debug_assert!(
                 w <= u8::MAX as usize,
@@ -297,7 +297,7 @@ impl Deserializable for TraceLayout {
     /// Returns an error of a valid [TraceLayout] struct could not be read from the specified
     /// `source`.
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let main_width = source.read_u8()? as usize;
+        let main_width = source.read_u16()? as usize;
         if main_width == 0 {
             return Err(DeserializationError::InvalidValue(
                 "main trace segment width must be greater than zero".to_string(),

--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -268,7 +268,7 @@ impl FieldExtension {
             Self::None => 1,
             Self::Quadratic => 2,
             Self::Cubic => 3,
-            Self::Sextic=>6,
+            Self::Sextic => 6,
         }
     }
 }

--- a/math/src/field/extensions/cubic.rs
+++ b/math/src/field/extensions/cubic.rs
@@ -347,49 +347,6 @@ impl<B: ExtensibleField<3> + StarkField> Deserializable for CubeExtension<B> {
     }
 }
 
-// QUADRATIC EXTENSION TO BUILD A SEXTIC EXTENSION
-// ================================================================================================
-
-/// Defines a quadratic extension of the cubic extension field using an irreducible polynomial x² + 3.
-/// Thus, a sextic extension element is defined as α + β * φ, where φ is a root of this polynomial,
-/// and α and β are cubic extension field elements.
-
-// Implementing the extension Fp^6 as Fp^3[x] / (x^2 + 3).
-impl<B: ExtensibleField<3> + StarkField> ExtensibleField<2> for CubeExtension<B>
-where
-    Self: FieldElement<BaseField = B>,
-{
-    #[inline(always)]
-    fn mul(a: [Self; 2], b: [Self; 2]) -> [Self; 2] {
-        let a0b0 = a[0] * b[0];
-        let a1b1 = a[1] * b[1];
-        [
-            a0b0 - a1b1 - a1b1 - a1b1,
-            (a[0] + a[1]) * (b[0] + b[1]) - a0b0 - a1b1,
-        ]
-    }
-
-    #[inline(always)]
-    fn mul_base(a: [Self; 2], b: Self) -> [Self; 2] {
-        // multiplying an extension field element by a base field element requires just 2
-        // multiplications in the cubic extension field.
-        [a[0] * b, a[1] * b]
-    }
-
-    #[inline(always)]
-    fn frobenius(x: [Self; 2]) -> [Self; 2] {
-        // given x = α + β * φ
-        // frobenius(x) = frobenius(α) + frobenius(β) * frobenius(φ)
-        //              = frobenius(α) - frobenius(β) * φ
-        let a = <B as ExtensibleField<3>>::frobenius([x[0].0, x[0].1, x[0].2]);
-        let b = <B as ExtensibleField<3>>::frobenius([x[1].0, x[1].1, x[1].2]);
-        [
-            CubeExtension::<B>::new(a[0], a[1], a[2]),
-            -CubeExtension::<B>::new(b[0], b[1], b[2]),
-        ]
-    }
-}
-
 // TESTS
 // ================================================================================================
 

--- a/math/src/field/extensions/sextic.rs
+++ b/math/src/field/extensions/sextic.rs
@@ -27,17 +27,20 @@ use utils::{
 /// field elements.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
-pub struct SexticExtension<B: ExtensibleField<3> + StarkField>(CubeExtension<B>, CubeExtension<B>);
+pub struct SexticExtension<B: ExtensibleField<3> + ExtensibleField<6> + StarkField>(
+    CubeExtension<B>,
+    CubeExtension<B>,
+);
 
-impl<B: ExtensibleField<3> + StarkField> SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> SexticExtension<B> {
     /// Returns a new extension element instantiated from the provided base elements.
     pub fn new(a: CubeExtension<B>, b: CubeExtension<B>) -> Self {
         Self(a, b)
     }
 
-    /// Returns true if the base field specified by B type parameter supports quadratic extensions.
+    /// Returns true if the base field specified by B type parameter supports sextic extensions.
     pub fn is_supported() -> bool {
-        <CubeExtension<B> as ExtensibleField<2>>::is_supported()
+        <B as ExtensibleField<6>>::is_supported()
     }
 
     /// Converts a vector of cubic extension elements into a vector of elements in a sextic
@@ -57,7 +60,7 @@ impl<B: ExtensibleField<3> + StarkField> SexticExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> FieldElement for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> FieldElement for SexticExtension<B> {
     type PositiveInteger = B::PositiveInteger;
     type BaseField = B;
 
@@ -85,8 +88,14 @@ impl<B: ExtensibleField<3> + StarkField> FieldElement for SexticExtension<B> {
 
     #[inline]
     fn conjugate(&self) -> Self {
-        let result = <CubeExtension<B> as ExtensibleField<2>>::frobenius([self.0, self.1]);
-        Self(result[0], result[1])
+        let x = [self.0, self.1];
+        let mut y: [B; 6] = Default::default();
+        y.copy_from_slice(<CubeExtension<B> as FieldElement>::as_base_elements(&x));
+        let r = <B as ExtensibleField<6>>::frobenius(y);
+        Self(
+            CubeExtension::new(r[0], r[1], r[2]),
+            CubeExtension::new(r[3], r[4], r[5]),
+        )
     }
 
     fn elements_as_bytes(elements: &[Self]) -> &[u8] {
@@ -133,24 +142,32 @@ impl<B: ExtensibleField<3> + StarkField> FieldElement for SexticExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> ExtensionOf<CubeExtension<B>> for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> ExtensionOf<CubeExtension<B>>
+    for SexticExtension<B>
+{
     #[inline(always)]
     fn mul_base(self, other: CubeExtension<B>) -> Self {
-        let result = <CubeExtension<B> as ExtensibleField<2>>::mul_base([self.0, self.1], other);
-        Self(result[0], result[1])
+        Self(self.0 * other, self.1 * other)
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> ExtensionOf<B> for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> ExtensionOf<B>
+    for SexticExtension<B>
+{
     #[inline(always)]
     fn mul_base(self, other: B) -> Self {
-        let result =
-            <CubeExtension<B> as ExtensibleField<2>>::mul_base([self.0, self.1], other.into());
-        Self(result[0], result[1])
+        let x = [self.0, self.1];
+        let mut y: [B; 6] = Default::default();
+        y.copy_from_slice(<CubeExtension<B> as FieldElement>::as_base_elements(&x));
+        let r = <B as ExtensibleField<6>>::mul_base(y, other);
+        Self(
+            CubeExtension::new(r[0], r[1], r[2]),
+            CubeExtension::new(r[3], r[4], r[5]),
+        )
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> Randomizable for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> Randomizable for SexticExtension<B> {
     const VALUE_SIZE: usize = Self::ELEMENT_BYTES;
 
     fn from_random_bytes(source: &[u8]) -> Option<Self> {
@@ -167,7 +184,7 @@ impl<B: ExtensibleField<3> + StarkField> Randomizable for SexticExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> fmt::Display for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> fmt::Display for SexticExtension<B> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({}, {})", self.0, self.1)
     }
@@ -176,7 +193,7 @@ impl<B: ExtensibleField<3> + StarkField> fmt::Display for SexticExtension<B> {
 // OVERLOADED OPERATORS
 // ------------------------------------------------------------------------------------------------
 
-impl<B: ExtensibleField<3> + StarkField> Add for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> Add for SexticExtension<B> {
     type Output = Self;
 
     #[inline]
@@ -185,14 +202,14 @@ impl<B: ExtensibleField<3> + StarkField> Add for SexticExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> AddAssign for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> AddAssign for SexticExtension<B> {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
         *self = *self + rhs
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> Sub for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> Sub for SexticExtension<B> {
     type Output = Self;
 
     #[inline]
@@ -201,32 +218,42 @@ impl<B: ExtensibleField<3> + StarkField> Sub for SexticExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> SubAssign for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> SubAssign for SexticExtension<B> {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
         *self = *self - rhs;
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> Mul for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> Mul for SexticExtension<B> {
     type Output = Self;
 
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        let result =
-            <CubeExtension<B> as ExtensibleField<2>>::mul([self.0, self.1], [rhs.0, rhs.1]);
-        Self(result[0], result[1])
+        let x0 = [self.0, self.1];
+        let mut y0: [B; 6] = Default::default();
+        y0.copy_from_slice(<CubeExtension<B> as FieldElement>::as_base_elements(&x0));
+
+        let x1 = [rhs.0, rhs.1];
+        let mut y1: [B; 6] = Default::default();
+        y1.copy_from_slice(<CubeExtension<B> as FieldElement>::as_base_elements(&x1));
+
+        let r = <B as ExtensibleField<6>>::mul(y0, y1);
+        Self(
+            CubeExtension::new(r[0], r[1], r[2]),
+            CubeExtension::new(r[3], r[4], r[5]),
+        )
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> MulAssign for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> MulAssign for SexticExtension<B> {
     #[inline]
     fn mul_assign(&mut self, rhs: Self) {
         *self = *self * rhs
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> Div for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> Div for SexticExtension<B> {
     type Output = Self;
 
     #[inline]
@@ -236,14 +263,14 @@ impl<B: ExtensibleField<3> + StarkField> Div for SexticExtension<B> {
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> DivAssign for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> DivAssign for SexticExtension<B> {
     #[inline]
     fn div_assign(&mut self, rhs: Self) {
         *self = *self / rhs
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> Neg for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> Neg for SexticExtension<B> {
     type Output = Self;
 
     #[inline]
@@ -255,48 +282,52 @@ impl<B: ExtensibleField<3> + StarkField> Neg for SexticExtension<B> {
 // TYPE CONVERSIONS
 // ------------------------------------------------------------------------------------------------
 
-impl<B: ExtensibleField<3> + StarkField> From<CubeExtension<B>> for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> From<CubeExtension<B>>
+    for SexticExtension<B>
+{
     fn from(value: CubeExtension<B>) -> Self {
         Self(value, CubeExtension::ZERO)
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> From<B> for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> From<B> for SexticExtension<B> {
     fn from(value: B) -> Self {
         Self(CubeExtension::from(value), CubeExtension::ZERO)
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> From<u128> for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> From<u128> for SexticExtension<B> {
     fn from(value: u128) -> Self {
         Self(CubeExtension::from(value), CubeExtension::ZERO)
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> From<u64> for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> From<u64> for SexticExtension<B> {
     fn from(value: u64) -> Self {
         Self(CubeExtension::from(value), CubeExtension::ZERO)
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> From<u32> for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> From<u32> for SexticExtension<B> {
     fn from(value: u32) -> Self {
         Self(CubeExtension::from(value), CubeExtension::ZERO)
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> From<u16> for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> From<u16> for SexticExtension<B> {
     fn from(value: u16) -> Self {
         Self(CubeExtension::from(value), CubeExtension::ZERO)
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> From<u8> for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> From<u8> for SexticExtension<B> {
     fn from(value: u8) -> Self {
         Self(CubeExtension::from(value), CubeExtension::ZERO)
     }
 }
-impl<'a, B: ExtensibleField<3> + StarkField> TryFrom<&'a [u8]> for SexticExtension<B> {
+impl<'a, B: ExtensibleField<3> + ExtensibleField<6> + StarkField> TryFrom<&'a [u8]>
+    for SexticExtension<B>
+{
     type Error = DeserializationError;
 
     /// Converts a slice of bytes into a field element; returns error if the value encoded in bytes
@@ -321,7 +352,7 @@ impl<'a, B: ExtensibleField<3> + StarkField> TryFrom<&'a [u8]> for SexticExtensi
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> AsBytes for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> AsBytes for SexticExtension<B> {
     fn as_bytes(&self) -> &[u8] {
         // TODO: take endianness into account
         let self_ptr: *const Self = self;
@@ -332,14 +363,16 @@ impl<B: ExtensibleField<3> + StarkField> AsBytes for SexticExtension<B> {
 // SERIALIZATION / DESERIALIZATION
 // ------------------------------------------------------------------------------------------------
 
-impl<B: ExtensibleField<3> + StarkField> Serializable for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> Serializable for SexticExtension<B> {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.0.write_into(target);
         self.1.write_into(target);
     }
 }
 
-impl<B: ExtensibleField<3> + StarkField> Deserializable for SexticExtension<B> {
+impl<B: ExtensibleField<3> + ExtensibleField<6> + StarkField> Deserializable
+    for SexticExtension<B>
+{
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let value0 = CubeExtension::read_from(source)?;
         let value1 = CubeExtension::read_from(source)?;
@@ -353,7 +386,7 @@ impl<B: ExtensibleField<3> + StarkField> Deserializable for SexticExtension<B> {
 #[cfg(test)]
 mod tests {
     use super::{CubeExtension, DeserializationError, FieldElement, SexticExtension};
-    use crate::field::f64::BaseElement;
+    use crate::field::f23201::BaseElement;
     use rand_utils::rand_value;
     use utils::AsBytes;
 

--- a/math/src/field/f128/mod.rs
+++ b/math/src/field/f128/mod.rs
@@ -288,6 +288,30 @@ impl ExtensibleField<3> for BaseElement {
     }
 }
 
+// SEXTIC EXTENSION
+// ================================================================================================
+
+/// Sextic extension for this field is not implemented.
+impl ExtensibleField<6> for BaseElement {
+    fn mul(_a: [Self; 6], _b: [Self; 6]) -> [Self; 6] {
+        unimplemented!()
+    }
+
+    #[inline(always)]
+    fn mul_base(_a: [Self; 6], _b: Self) -> [Self; 6] {
+        unimplemented!()
+    }
+
+    #[inline(always)]
+    fn frobenius(_x: [Self; 6]) -> [Self; 6] {
+        unimplemented!()
+    }
+
+    fn is_supported() -> bool {
+        false
+    }
+}
+
 // TYPE CONVERSIONS
 // ================================================================================================
 

--- a/math/src/field/mod.rs
+++ b/math/src/field/mod.rs
@@ -7,10 +7,10 @@ mod traits;
 pub use traits::{ExtensibleField, ExtensionOf, FieldElement, StarkField};
 
 pub mod f128;
-pub mod f62;
-pub mod f64;
 pub mod f23;
 pub mod f23201;
+pub mod f62;
+pub mod f64;
 
 mod extensions;
 pub use extensions::{CubeExtension, QuadExtension, SexticExtension};

--- a/math/src/field/traits.rs
+++ b/math/src/field/traits.rs
@@ -162,7 +162,7 @@ pub trait FieldElement:
             prod_inv *= x[i];
         }
         prod.truncate(n);
-        return prod;
+        prod
     }
 
     // SERIALIZATION / DESERIALIZATION

--- a/math/src/lib.rs
+++ b/math/src/lib.rs
@@ -105,10 +105,10 @@ pub mod fields {
     //! of these field.
 
     pub use super::field::f128;
-    pub use super::field::f62;
-    pub use super::field::f64;
     pub use super::field::f23;
     pub use super::field::f23201;
+    pub use super::field::f62;
+    pub use super::field::f64;
     pub use super::field::CubeExtension;
     pub use super::field::QuadExtension;
     pub use super::field::SexticExtension;

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -122,7 +122,7 @@ pub mod tests;
 /// return from [Prover::options] method.
 pub trait Prover {
     /// Base field for the computation described by this prover.
-    type BaseField: StarkField + ExtensibleField<2> + ExtensibleField<3>;
+    type BaseField: StarkField + ExtensibleField<2> + ExtensibleField<3> + ExtensibleField<6>;
 
     /// Algebraic intermediate representation (AIR) for the computation described by this prover.
     type Air: Air<BaseField = Self::BaseField>;


### PR DESCRIPTION
writer was using u8 to serialize the width of the table and as a result truncation occurred. Now using u16.